### PR TITLE
Fix network timeout issue for yarn install command for WebSPA

### DIFF
--- a/src/Web/WebSPA/Dockerfile
+++ b/src/Web/WebSPA/Dockerfile
@@ -10,7 +10,7 @@ FROM ${NODE_IMAGE} as node-build
 WORKDIR /web
 COPY Client/package.json .
 COPY Client/yarn.lock .
-RUN yarn install
+RUN yarn install --network-timeout 100000
 COPY Client/ .
 RUN yarn build
 


### PR DESCRIPTION
Prior to this change, starting the app locally via docker compose script kept failing with an error

This change increases the network timeout for yarn install command in WebSPA

resoves #13 